### PR TITLE
auto-generate hostname as ca_hostname var

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,5 +1,5 @@
 [capture-agents-v4l2-split]
-#example-ca ansible_ssh_host=127.0.0.1 ansible_ssh_port=22 ansible_release_host=127.0.0.1 ansible_uom_hostname=example-hostname support_group=example-support home_tunnel_port=22 nagios_tunnel_port=None deploy_environment=staging name_mask=None ansible_failovermic=FALSE CA_interactive=None oc_default_series=None oc_default_email=None vl_public=false blinkstick=False vapix_inverted=true ptz_tilt_lock=false vl_private_ep_acl=False cam1_host=192.168.0.90 cam2_host=None CA_interactive_role=example-role
+#example-ca ansible_ssh_host=127.0.0.1 ansible_ssh_port=22 ansible_release_host=127.0.0.1 support_group=example-support home_tunnel_port=22 nagios_tunnel_port=None deploy_environment=staging name_mask=None ansible_failovermic=FALSE CA_interactive=None oc_default_series=None oc_default_email=None vl_public=false blinkstick=False vapix_inverted=true ptz_tilt_lock=false vl_private_ep_acl=False cam1_host=192.168.0.90 cam2_host=None CA_interactive_role=example-role
 
 [capture-agents-blackmagic-split-wifi]
 
@@ -34,10 +34,10 @@
 [capture-agents-datapath-usb]
 
 [capture-agents-dual-datapath-split]
-#example-ca ansible_ssh_host=127.0.0.1 ansible_ssh_port=22 ansible_release_host=127.0.0.1 ansible_uom_hostname=example-hostname support_group=example-support home_tunnel_port=22 nagios_tunnel_port=None deploy_environment=staging name_mask=None ansible_failovermic=FALSE CA_interactive=None oc_default_series=None oc_default_email=None vl_public=false blinkstick=False vapix_inverted=true ptz_tilt_lock=false vl_private_ep_acl=False cam1_host=192.168.0.90 cam2_host=None CA_interactive_role=example-role
-vision.csi.cam.ac.uk ansible_ssh_host=131.111.56.116 ansible_ssh_port=22 ansible_release_host=127.0.0.1 ansible_uom_hostname=vision.csi.cam.ac.uk support_group=example-support home_tunnel_port=22 nagios_tunnel_port=None deploy_environment=staging name_mask=None ansible_failovermic=FALSE CA_interactive=None oc_default_series=None oc_default_email=None vl_public=false blinkstick=False vapix_inverted=true ptz_tilt_lock=false vl_private_ep_acl=False cam1_host=192.168.0.90 cam2_host=None CA_interactive_role=example-role
+#example-ca ansible_ssh_host=127.0.0.1 ansible_ssh_port=22 ansible_release_host=127.0.0.1 support_group=example-support home_tunnel_port=22 nagios_tunnel_port=None deploy_environment=staging name_mask=None ansible_failovermic=FALSE CA_interactive=None oc_default_series=None oc_default_email=None vl_public=false blinkstick=False vapix_inverted=true ptz_tilt_lock=false vl_private_ep_acl=False cam1_host=192.168.0.90 cam2_host=None CA_interactive_role=example-role
+vision.csi.cam.ac.uk ansible_ssh_host=131.111.56.116 ansible_ssh_port=22 ansible_release_host=127.0.0.1 support_group=example-support home_tunnel_port=22 nagios_tunnel_port=None deploy_environment=staging name_mask=None ansible_failovermic=FALSE CA_interactive=None oc_default_series=None oc_default_email=None vl_public=false blinkstick=False vapix_inverted=true ptz_tilt_lock=false vl_private_ep_acl=False cam1_host=192.168.0.90 cam2_host=None CA_interactive_role=example-role
 
-uis-capture-agent-02 ansible_ssh_host=172.24.113.133 ansible_ssh_port=22 ansible_release_host=127.0.0.1 ansible_uom_hostname=uis-capture-agent-02 support_group=example-support home_tunnel_port=22 nagios_tunnel_port=None deploy_environment=staging name_mask=None ansible_failovermic=FALSE CA_interactive=None oc_default_series=None oc_default_email=None vl_public=false blinkstick=False vapix_inverted=true ptz_tilt_lock=false vl_private_ep_acl=False cam1_host=None cam2_host=None CA_interactive_role=example-role
+uis-capture-agent-02 ansible_ssh_host=172.24.113.133 ansible_ssh_port=22 ansible_release_host=127.0.0.1 support_group=example-support home_tunnel_port=22 nagios_tunnel_port=None deploy_environment=staging name_mask=None ansible_failovermic=FALSE CA_interactive=None oc_default_series=None oc_default_email=None vl_public=false blinkstick=False vapix_inverted=true ptz_tilt_lock=false vl_private_ep_acl=False cam1_host=None cam2_host=None CA_interactive_role=example-role
 
 [capture-agents-dual-datapath-usb]
 

--- a/roles/capture-agent-common/templates/hostname
+++ b/roles/capture-agent-common/templates/hostname
@@ -1,2 +1,2 @@
-{{ hostvars[inventory_hostname].ansible_default_ipv4.macaddress | friendly_hostname }}
+{{ ca_hostname }}
 

--- a/roles/capture-agent-common/vars/main.yml
+++ b/roles/capture-agent-common/vars/main.yml
@@ -5,5 +5,5 @@ manchester_deb_repo: "{{ deb_repo_hostname }}{{ UOM_deb_release }}"
 
 logfile: "{{ GC_log_path }}"
 
-ca_hostname: "{{ ansible_uom_hostname }}"
+ca_hostname: "{{ hostvars[inventory_hostname].ansible_default_ipv4.macaddress | friendly_hostname }}"
 ip_address: "{{ ansible_release_host|default('dhcp') }}"

--- a/roles/galicaster-capture-agent-common/vars/main.yml
+++ b/roles/galicaster-capture-agent-common/vars/main.yml
@@ -3,7 +3,7 @@
 
 matterhorn_workflow: "{{ GC_matterhorn_workflow }}"
 ingest_time: "{{ GC_ingest_time }}"
-ca_hostname: "{{ ansible_uom_hostname }}"
+ca_hostname: "{{ hostvars[inventory_hostname].ansible_default_ipv4.macaddress | friendly_hostname }}"
 ip_address: "{{ ansible_release_host|default(dhcp) }}"
 
 GC_support_group: "{{ support_group|default(mtt) }}"


### PR DESCRIPTION
The ca_hostname variable should be the hostname of the capture agent.  Instead of generating it in the /etc/hostname template, actually generate the ca_hostname variable. Remove references to ansible_uom_hostname which is now unused.