### PR TITLE
tweak Galicaster heartbeat frequency

### DIFF
--- a/roles/galicaster-capture-agent-common/templates/conf_ini.j2
+++ b/roles/galicaster-capture-agent-common/templates/conf_ini.j2
@@ -63,8 +63,8 @@ peakaboolive = {{ peakaboolive }}
 
 [heartbeat]
 night = {{ ['20','21','22','23','00','01','02','03','04'] | random }}:{{ 5 | random }}{{ 9 | random }}
-short = 60
-long = 600
+short = 10
+long = 60
 
 [backuprepo]
 mount_point = /mnt/backup-repo


### PR DESCRIPTION
Tweak the frequency at which galicaster "phones home". Use 10 seconds for "short" heartbeats ("I am alive") and 60 seconds for "long" heartbeats ("what recordings should I schedule"). We may want to lengthen them in time but for the moment we want them to be short for testing.