### PR TITLE
Switched to use the new Cambridge-default workflow (by default)

### DIFF
--- a/group_vars/capture-agents-magewell-split
+++ b/group_vars/capture-agents-magewell-split
@@ -2,7 +2,7 @@
 GC_profile: Magewell Split Audio
 GC_checkaudiosource_low_alert: -50
 GC_checkaudiosource_check_recording: True
-GC_matterhorn_workflow: Cambridge-default
+GC_matterhorn_workflow: cam-default
 
 livestream_cmd: ffmpeg -f v4l2 -framerate 30 -video_size hd720 -input_format yuyv422 -thread_queue_size 512 -i /dev/datapath0 -f alsa -ac 2 -thread_queue_size 512 -i pulse -vcodec libx264 -preset veryfast -crf 17 -b:v 6000k -c:a libmp3lame -ar 44100 -f flv rtmp://a.rtmp.youtube.com/live2/{{youtube_stream_key}}
 

--- a/group_vars/capture-agents-magewell-split
+++ b/group_vars/capture-agents-magewell-split
@@ -2,6 +2,7 @@
 GC_profile: Magewell Split Audio
 GC_checkaudiosource_low_alert: -50
 GC_checkaudiosource_check_recording: True
+GC_matterhorn_workflow: Cambridge-default
 
 livestream_cmd: ffmpeg -f v4l2 -framerate 30 -video_size hd720 -input_format yuyv422 -thread_queue_size 512 -i /dev/datapath0 -f alsa -ac 2 -thread_queue_size 512 -i pulse -vcodec libx264 -preset veryfast -crf 17 -b:v 6000k -c:a libmp3lame -ar 44100 -f flv rtmp://a.rtmp.youtube.com/live2/{{youtube_stream_key}}
 


### PR DESCRIPTION
This makes the default workflow for magewell CAs the new 'Cambridge-default' and sets the default Galicaster profile to slides and audio.

Closes #19 