### PR TITLE
Prevent the magewell driver installation hanging

### DIFF
--- a/roles/galicaster-capture-agent-magewell-common/tasks/main.yml
+++ b/roles/galicaster-capture-agent-magewell-common/tasks/main.yml
@@ -17,7 +17,7 @@
     - magewell_drivers
 
 - name: "Install Magewell Drivers"
-  command: ./install.sh -s
+  shell: Y '' | ./install.sh -s
   args:
     chdir: /opt/magewell/ProCaptureForLinux_3950/
   register: magewell_driver_installed


### PR DESCRIPTION
Without the hack the playbook installs the magewell driver successfully
on the first run, but subsequent runs stall waiting for confirmation on
reinstalling the driver.

With the hack the playbook completes without waiting.