### PR TITLE
Explictly select source to ensure stereo recording

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -49,6 +49,3 @@ onvif_user: onvif
 
 # youtube live stream key for livestreaming
 youtube_stream_key: youtube-stream-key
-
-# pulse audio server name
-pa_server_name: unix:/run/user/1000/pulse/native

--- a/group_vars/all
+++ b/group_vars/all
@@ -49,3 +49,6 @@ onvif_user: onvif
 
 # youtube live stream key for livestreaming
 youtube_stream_key: youtube-stream-key
+
+# pulse audio server name
+pa_server_name: unix:/run/user/1000/pulse/native

--- a/roles/v4l2-common/tasks/main.yml
+++ b/roles/v4l2-common/tasks/main.yml
@@ -32,7 +32,7 @@
     - v4l_devices
 
 - name: "Set the line in source port for 'Stereo Input For Microphone'"
-  shell: pactl --server={{ pa_server_name }} set-source-port {{ GC_line_in_source }} analog-input-headphone-mic
+  shell: pactl --server=unix:/run/user/$(id -u {{ ca_username }})/pulse/native set-source-port {{ GC_line_in_source }} analog-input-headphone-mic
   become: true
   become_user: "{{ ca_username }}"
   tags: pactl_set_source_port

--- a/roles/v4l2-common/tasks/main.yml
+++ b/roles/v4l2-common/tasks/main.yml
@@ -30,3 +30,9 @@
     - galicaster_config
     - galicaster_profiles
     - v4l_devices
+
+- name: "Set the line in source port for 'Stereo Input For Microphone'"
+  shell: pactl --server={{ pa_server_name }} set-source-port {{ GC_line_in_source }} analog-input-headphone-mic
+  become: true
+  become_user: "{{ ca_username }}"
+  tags: pactl_set_source_port


### PR DESCRIPTION
There are two options for the pulse audio line in source port: analog-input-headphone-mic & analog-input-headset-mic. By default analog-input-headset-mic is selected but we need analog-input-headphone-mic for stereo - so explicitly select that.