### PR TITLE
Dual v4l2 support for agent

### DIFF
--- a/capture-agent.yml
+++ b/capture-agent.yml
@@ -88,7 +88,7 @@
     http_proxy: "{{ http_proxy_server }}"
     https_proxy: "{{ https_proxy_server }}"
 
-- hosts: capture-agents-v4l2-split:capture-agents-v4l2-usb
+- hosts: capture-agents-v4l2-split:capture-agents-v4l2-usb:capture-agents-dual-v4l2-split
   remote_user: root
   roles:
       - v4l2-common

--- a/dev-hosts
+++ b/dev-hosts
@@ -58,6 +58,9 @@
 #uis-capture-agent-03 ansible_host=172.24.193.170 ansible_ssh_port=22
 #uis-capture-agent-04 ansible_host=172.24.193.212 ansible_ssh_port=22
 
+[capture-agents-dual-v4l2-split]
+#uis-capture-agent-42 ansible_host=172.24.193.212 ansible_ssh_port=22
+
 [capture-agents-blackmagic-split:children]
 capture-agents-blackmagic-split-wifi
 
@@ -112,6 +115,7 @@ capture-agents-magewell-split
 capture-agents-v4l2-x2-axis-muxed
 capture-agents-v4l2-usb
 capture-agents-v4l2-split
+capture-agents-dual-v4l2-split
 
 [capture-agents:children]
 capture-agents-blackmagic

--- a/group_vars/capture-agents-dual-v4l2-split
+++ b/group_vars/capture-agents-dual-v4l2-split
@@ -1,21 +1,18 @@
 ---
+GC_encoder: vaapih264enc
+GC_encoder_high: vaapih264enc
 
-GC_encoder: vaapipostproc ! vaapih264enc rate-control=cbr bitrate=2000
-GC_encoder_high: vaapipostproc ! vaapih264enc rate-control=cbr bitrate=6000
-
-DP_video_name_0: /dev/video0
-DP_video_name_1: /dev/video1
 v4l2_caps: image/jpeg,format=YUY2
-DP_framerate: 24/1
-DP_width: 1280
-DP_height: 720
+DP_framerate: 30/1
+DP_width: 1920
+DP_height: 1080
 DP_driver: False
 
-GC_profile: Screen
+GC_profile: Dual Screen/Camera and Line In Audio
 
 GC_resolution: auto
 
-GC_qrcode_ignore_track: camera
+#GC_qrcode_ignore_track: camera
 
 max_save_mp_days: 7
 
@@ -33,3 +30,22 @@ GC_checkaudiosource_check_recording: True
 CA_camctrl: False
 CA_vapixctrl: False
 camera_exists: False
+
+ansible_release_host: 127.0.0.1
+support_group: example-support
+home_tunnel_port: 22
+nagios_tunnel_port: null
+deploy_environment: staging
+name_mask: null
+ansible_failovermic: false
+CA_interactive: null
+oc_default_series: tests
+oc_default_email: null
+vl_public: false
+blinkstick: false
+vapix_inverted: true
+ptz_tilt_lock: false
+vl_private_ep_acl: false
+cam1_host: null
+cam2_host: null
+CA_interactive_role: example-role

--- a/group_vars/capture-agents-dual-v4l2-split
+++ b/group_vars/capture-agents-dual-v4l2-split
@@ -4,8 +4,8 @@ GC_encoder_high: vaapih264enc
 
 v4l2_caps: image/jpeg,format=YUY2
 DP_framerate: 30/1
-DP_width: 1920
-DP_height: 1080
+DP_width: 1280
+DP_height: 720
 DP_driver: False
 
 GC_profile: Dual Screen/Camera and Line In Audio

--- a/prod-hosts
+++ b/prod-hosts
@@ -70,6 +70,9 @@ boring-haslett-515      ansible_host=10.222.4.146   ansible_ssh_port=22
 # Sidgwick Lecture Block - Room 6
 happy-clarke-812        ansible_host=10.222.4.156   ansible_ssh_port=22
 
+[capture-agents-dual-v4l2-split]
+#uis-capture-agent-42 ansible_host=172.24.193.212 ansible_ssh_port=22
+
 [capture-agents-blackmagic-split:children]
 capture-agents-blackmagic-split-wifi
 
@@ -124,6 +127,7 @@ capture-agents-magewell-split
 capture-agents-v4l2-x2-axis-muxed
 capture-agents-v4l2-usb
 capture-agents-v4l2-split
+capture-agents-dual-v4l2-split
 
 [capture-agents:children]
 capture-agents-blackmagic

--- a/roles/capture-agent-common/tasks/set_facts.yml
+++ b/roles/capture-agent-common/tasks/set_facts.yml
@@ -133,7 +133,7 @@
 - name: setting facts for Line In Source
   set_fact:
     GC_line_in_source: "{{ line_in_source.stdout }}"
-  when: line_in_source.stdout != '' and inventory_hostname in groups['capture-agents-v4l2-split']
+  when: line_in_source.stdout != '' and (inventory_hostname in groups['capture-agents-v4l2-split'] or inventory_hostname in groups['capture-agents-dual-v4l2-split'])
 
 - name: setting user interactive facts
   set_fact:

--- a/roles/v4l2-common/templates/profiles/dual-v4l2-split.ini
+++ b/roles/v4l2-common/templates/profiles/dual-v4l2-split.ini
@@ -1,5 +1,5 @@
 [data]
-name = Dual v4l2 Split Audio
+name = Dual Screen/Camera and Line In Audio
 
 [track1]
 name = camera

--- a/roles/v4l2-common/templates/profiles/dual-v4l2-split.ini
+++ b/roles/v4l2-common/templates/profiles/dual-v4l2-split.ini
@@ -9,6 +9,7 @@ location = /dev/video-presenter
 file = presenter.avi
 caps = video/x-raw,format=YUY2,framerate={{ DP_framerate }},width={{ DP_width }},height={{ DP_height }}
 videoencoder = {{ GC_encoder_high }}
+type = video/screen
 
 [track2]
 name = screen
@@ -18,6 +19,7 @@ location = /dev/video-presentation
 file = presentation.avi
 caps = video/x-raw,format=YUY2,framerate={{ DP_framerate }},width={{ DP_width }},height={{ DP_height }}
 videoencoder = {{ GC_encoder }}
+type = video/screen
 
 [track3]
 name = AudioSource
@@ -28,4 +30,4 @@ location = {{ GC_line_in_source }}
 file = presenter.mp3
 amplification = 1.0
 vumeter = true
-delay = 0.21
+type = audio/pulse

--- a/test-hosts
+++ b/test-hosts
@@ -58,6 +58,9 @@
 #uis-capture-agent-03 ansible_host=172.24.193.170 ansible_ssh_port=22
 #uis-capture-agent-04 ansible_host=172.24.193.212 ansible_ssh_port=22
 
+[capture-agents-dual-v4l2-split]
+#uis-capture-agent-42 ansible_host=172.24.193.212 ansible_ssh_port=22
+
 [capture-agents-blackmagic-split:children]
 capture-agents-blackmagic-split-wifi
 
@@ -112,6 +115,7 @@ capture-agents-magewell-split
 capture-agents-v4l2-x2-axis-muxed
 capture-agents-v4l2-usb
 capture-agents-v4l2-split
+capture-agents-dual-v4l2-split
 
 [capture-agents:children]
 capture-agents-blackmagic


### PR DESCRIPTION
Missing part of configuration for agents for issue uisautomation/lecture-capture-backend#124

Creates group for **dual-v4l2-split** and updates profile to match that of single feed